### PR TITLE
compatibility update for 223 (2022.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # intellij-cute-pink-light-theme Changelog
 
+## 0.7.0 - unreleased
+### Fixed
+- Ensure compatibility for 2022.3 stable (223, 2022.3)
+
 ## 0.6.4 - 2022-11-07
 ### Fixed
 - Ensure compatibility for 2022.2 stable (222, PS-222.*, 2022.2)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@
 pluginGroup = com.github.openmindculture.intellijcutepinklighttheme
 pluginName = intellij-cute-pink-light-theme
 
-pluginVersion = 0.6.4
+pluginVersion = 0.7.0
 pluginSinceBuild = 202
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.4, 2021.3, 2022.1, 2022.2
+pluginVerifierIdeVersions = 2020.2.4, 2021.3, 2022.1, 2022.2, 2022.3
 
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2022.3
 
 platformDownloadSources = true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
     <id>com.github.openmindculture.intellijcutepinklighttheme</id>
     <description>Cute Pink Light Theme for IntelliJ Platform inspired by WebFreak's Cute Pink Light Theme for VisualStudio Code.</description>
     <change-notes>Initial theme release. Basic theme functionality.</change-notes>
-    <version>0.6.4</version>
+    <version>0.7.0</version>
     <vendor url="https://github.com/openmindculture/">Ingo Steinke (openmindculture)</vendor>
 
     <!-- Compatible with the following versions of IntelliJ Platform:


### PR DESCRIPTION
closes #93

WIP as long as no current EAP build is compatible with any of my local JDK/VJM/JRE versions.